### PR TITLE
lock fix

### DIFF
--- a/src/iwc/Lock.js
+++ b/src/iwc/Lock.js
@@ -152,10 +152,7 @@
         }
         var lockBelongsToThisWindow = lockInfo.ownerWindowId === SJ.iwc.WindowMonitor.getThisWindowId();
         var lockBelongsToClosedWindow = !SJ.iwc.WindowMonitor.isWindowOpen(lockInfo.ownerWindowId);
-        if (lockBelongsToClosedWindow || (lockBelongsToThisWindow && (findLock(lockId) === -1))) {//junk lock
-            return true;
-        }
-        return false;
+        return lockBelongsToClosedWindow || (lockBelongsToThisWindow && (findLock(lockId) === -1));
     };
 
     function releaseAllLocks() {

--- a/src/iwc/WindowMonitor.js
+++ b/src/iwc/WindowMonitor.js
@@ -115,10 +115,10 @@
                 closedWindows.push(windowId);
             }
         }
+        openWindows = newOpenWindows;
         if (newWindows.length || closedWindows.length) {
             onWindowsChanged(newWindows, closedWindows);
         }
-        openWindows = newOpenWindows;
     };
 
     function onWindowsChanged(newWindows, closedWindows) {


### PR DESCRIPTION
1) fixes updateDataFromStorage so that it updates openWindows before firing the onWindowsChanged event, which triggers clearJunkLocks, which needs to know whether found lock belongs to a closed window and it relies on openWindows for that
2) fixes clearJunkLocks so that it uses interlockedCall with the same id as the lock obtaining code, which gets it in sync with other tabs and solves the problem of removing and obtaining the same lock at the same time in different tabs